### PR TITLE
자동으로 브라우저가 열리도록 하는 `yarn run start:open` 명령어를 추가해라

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "start": "webpack serve --mode development",
     "relay": "relay-compiler",
     "relay:watch": "yarn run relay --watch",
+    "start:open": "webpack serve --mode development --open",
     "test": "jest --watchAll --env=jsdom",
     "test-e2e": "npx codeceptjs run --steps"
   },


### PR DESCRIPTION
## Why
- resolve #21 

## What
- webpack.conf.js에 open 옵션 활성화
