### PR TITLE
GraphqQL Schema gen 커맨드 추가

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "start": "webpack serve --mode development",
     "relay": "relay-compiler",
     "relay:watch": "yarn run relay --watch",
+    "gen:schema": "get-graphql-schema http://localhost:3000/graphql > ./src/graphql/schema.graphql",
     "start:open": "webpack serve --mode development --open",
     "test": "jest --watchAll --env=jsdom",
     "test-e2e": "npx codeceptjs run --steps"

--- a/client/src/graphql/schema.graphql
+++ b/client/src/graphql/schema.graphql
@@ -1,3 +1,23 @@
+"""Exposes a URL that specifies the behaviour of this scalar."""
+directive @specifiedBy(
+  """The URL that specifies the behaviour of this scalar."""
+  url: String!
+) on SCALAR
+
+type Auth {
+  accessToken: String
+}
+
+type Mutation {
+  login(code: String!): Auth!
+}
+
+type Query {
+  allQuestionCategories: [QuestionCategory!]!
+  allQuestions: [Question!]!
+  allUsers: [User!]!
+}
+
 type Question {
   id: ID!
   title: String
@@ -7,14 +27,15 @@ type Question {
   frequency: Boolean
 }
 
-type Auth {
-  accessToken: String
+type QuestionCategory {
+  id: ID!
+  title: String!
 }
 
-type Query {
-  allQuestions: [Question!]!
+type User {
+  id: ID!
+  email: String!
+  name: String
+  bookmarks: [Int]
 }
 
-type Mutation {
-  login(code: String!): Auth!
-}


### PR DESCRIPTION
```
$ npm install -g get-graphql-schema
```
로 해당 모듈 설치 후 서버 실행한 다음 해당 명령어를 돌리면 자동으로 서버의 스키마를 받아서 클라이언트에 저장해줍니다.
원래는 production에 배포된 서버가 있다면 해당 서버를 커맨드에 넣으면 되는데 아직 배포된게 없어서 로컬 서버 URL로 추가했어요.

## Why

- 매번 서버 스키마 일일이 수기로 작성해서 클라로 옮기는 노가다를 참을 수 없어서

## What

- 커맨드를 추가함. `yarn run gen:schema` 하면 스키마 자동으로 생성

## Notes

- 추후 서버를 띄우면 로컬서버가 아닌 배포된 서버의 URL로 교체해야함
