### PR TITLE
`yarn run gen:schema` 명령어 동작 안하는 문제 해결

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "get-graphql-schema": "^2.1.2",
     "graphql": "^15.5.1",
     "html-webpack-plugin": "^5.3.1",
     "jest": "^27.0.4",


### PR DESCRIPTION
## Why

- `yarn run gen:schema` 명령어 동작 안하는 문제 해결

## What
- 종속성(`get-graphql-schema`) 추가

## Notes
- `yarn run gen:schema` 명령어 실행시, 서버 `yarn start` 필수!
