### PR TITLE
`withPromiseComponent` 구현

### DIFF
--- a/client/src/hocs/withPromiseComponent.tsx
+++ b/client/src/hocs/withPromiseComponent.tsx
@@ -1,0 +1,21 @@
+import React, { ComponentType, Suspense } from 'react';
+
+import ErrorBoundary from '../helper/Errorboundary';
+
+const withPromiseComponent = (
+  PenddingComponent: ComponentType,
+  ResolveComponent: ComponentType,
+  RejectComponent: ComponentType,
+) => {
+  const PromiseComponent = () => (
+    <ErrorBoundary fallback={<RejectComponent />}>
+      <Suspense fallback={<PenddingComponent />}>
+        <ResolveComponent />
+      </Suspense>
+    </ErrorBoundary>
+  );
+
+  return PromiseComponent;
+};
+
+export default withPromiseComponent;


### PR DESCRIPTION
## Why

- 비동기 로직이 포함된 컴포넌트를 위한 HOC 

## What

- `withPromiseComponent` 구현 

## Notes
- 이것도 Sentry 테스트 완료했어요~
- 추가로, 우민님이 Errorboundary를 왜 Suspense 밖에다 하는지 질문주셨는데, Suspense 자체도 컴포넌트이므로, Suspense에서 발생하는 에러도 잡기 싶으면 밖에다 선언해줘야 하더라구요~ 관련 내용 [공식문서](https://ko.reactjs.org/docs/concurrent-mode-suspense.html#handling-errors)에 나와서 자료 첨부합니다.