### PR TITLE
[Client] 댓글 확인 및 작성 기능을 구현한다

### DIFF
--- a/client/src/__generated__/CommentPageMutation.graphql.ts
+++ b/client/src/__generated__/CommentPageMutation.graphql.ts
@@ -1,0 +1,191 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CommentPageMutationVariables = {
+    questionId?: number | null;
+    userEmail?: string | null;
+    content?: string | null;
+};
+export type CommentPageMutationResponse = {
+    readonly addComment: {
+        readonly " $fragmentRefs": FragmentRefs<"Comment_comment">;
+    } | null;
+};
+export type CommentPageMutation = {
+    readonly response: CommentPageMutationResponse;
+    readonly variables: CommentPageMutationVariables;
+};
+
+
+
+/*
+mutation CommentPageMutation(
+  $questionId: Int
+  $userEmail: String
+  $content: String
+) {
+  addComment(questionId: $questionId, userEmail: $userEmail, content: $content) {
+    ...Comment_comment
+    id
+  }
+}
+
+fragment Comment_comment on Comment {
+  id
+  questionId
+  createdAt
+  userEmail
+  content
+  like
+  dislike
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "content"
+    } as any, v1 = {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "questionId"
+    } as any, v2 = {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "userEmail"
+    } as any, v3 = [
+        {
+            "kind": "Variable",
+            "name": "content",
+            "variableName": "content"
+        } as any,
+        {
+            "kind": "Variable",
+            "name": "questionId",
+            "variableName": "questionId"
+        } as any,
+        {
+            "kind": "Variable",
+            "name": "userEmail",
+            "variableName": "userEmail"
+        } as any
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": [
+                (v0 /*: any*/),
+                (v1 /*: any*/),
+                (v2 /*: any*/)
+            ],
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "CommentPageMutation",
+            "selections": [
+                {
+                    "alias": null,
+                    "args": (v3 /*: any*/),
+                    "concreteType": "Comment",
+                    "kind": "LinkedField",
+                    "name": "addComment",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "Comment_comment"
+                        }
+                    ],
+                    "storageKey": null
+                }
+            ],
+            "type": "Mutation",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": [
+                (v1 /*: any*/),
+                (v2 /*: any*/),
+                (v0 /*: any*/)
+            ],
+            "kind": "Operation",
+            "name": "CommentPageMutation",
+            "selections": [
+                {
+                    "alias": null,
+                    "args": (v3 /*: any*/),
+                    "concreteType": "Comment",
+                    "kind": "LinkedField",
+                    "name": "addComment",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "id",
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "questionId",
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "userEmail",
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "content",
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "like",
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dislike",
+                            "storageKey": null
+                        }
+                    ],
+                    "storageKey": null
+                }
+            ]
+        },
+        "params": {
+            "cacheID": "d51be9613e606657038a124040c54cf8",
+            "id": null,
+            "metadata": {},
+            "name": "CommentPageMutation",
+            "operationKind": "mutation",
+            "text": "mutation CommentPageMutation(\n  $questionId: Int\n  $userEmail: String\n  $content: String\n) {\n  addComment(questionId: $questionId, userEmail: $userEmail, content: $content) {\n    ...Comment_comment\n    id\n  }\n}\n\nfragment Comment_comment on Comment {\n  id\n  questionId\n  createdAt\n  userEmail\n  content\n  like\n  dislike\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = 'f3d465960dc72eb2964fe3a6b28b70c3';
+export default node;

--- a/client/src/graphql/schema.graphql
+++ b/client/src/graphql/schema.graphql
@@ -19,8 +19,15 @@ type Comment {
   subComments: [SubComments]
 }
 
+input NewComment {
+  questionId: Int
+  userEmail: String
+  content: String
+}
+
 type Mutation {
   login(code: String!): Auth!
+  addComment(newComment: NewComment): Int
 }
 
 type Query {

--- a/client/src/graphql/schema.graphql
+++ b/client/src/graphql/schema.graphql
@@ -16,18 +16,12 @@ type Comment {
   content: String
   like: [String]
   dislike: [String]
-  subComments: [SubComments]
-}
-
-input NewComment {
-  questionId: Int
-  userEmail: String
-  content: String
+  subComments: [SubComment]
 }
 
 type Mutation {
   login(code: String!): Auth!
-  addComment(newComment: NewComment): Int
+  addComment(questionId: Int, userEmail: String, content: String): Comment
 }
 
 type Query {
@@ -51,7 +45,7 @@ type QuestionCategory {
   title: String!
 }
 
-type SubComments {
+type SubComment {
   id: ID!
   createdAt: String
   userEmail: String

--- a/client/src/page/CommentPage.tsx
+++ b/client/src/page/CommentPage.tsx
@@ -110,7 +110,9 @@ const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
             onChange={handleOnChangeInput}
           />
         </label>
-        <input type="submit" value="등록" />
+        <button type="submit">
+          등록
+        </button>
       </form>
     </section>
   );

--- a/client/src/page/CommentPage.tsx
+++ b/client/src/page/CommentPage.tsx
@@ -1,49 +1,26 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { QueryRenderer, graphql } from 'react-relay';
 
 import Environment from '../graphql';
-import { CommentPageQuery, CommentPageQueryResponse } from '../__generated__/CommentPageQuery.graphql';
+import { CommentPageQuery } from '../__generated__/CommentPageQuery.graphql';
 
 import Comment from '../components/Example/Comment';
 
-interface IRenderQuery {
-  error: Error | null;
-  props: CommentPageQueryResponse | null;
-}
+const CommentPage: React.FC = () => {
+  const [commentInput, setCommentInput] = useState('');
 
-const renderQuery = ({ error, props }: IRenderQuery) => {
-  if (!props) {
-    return <div>...로딩중</div>;
-  }
+  const handleOnChangeInput = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setCommentInput(event.target.value);
+  }, []);
 
-  if (error) {
-    return <div>...에러발생</div>;
-  }
+  const handleOnSubmit = useCallback((event: React.FormEvent) => {
+    event.preventDefault();
+  }, []);
 
   return (
-    <section>
-      <h2>
-        댓글
-      </h2>
-      {props.comments.length === 0
-        ? <p>댓글이 없습니다</p>
-        : (
-          <ol>
-            {props.comments.map((comment) => (
-              <li key={comment.id}>
-                <Comment comment={comment} />
-              </li>
-            ))}
-          </ol>
-        )}
-    </section>
-  );
-};
-
-const CommentPage: React.FC = () => (
-  <QueryRenderer<CommentPageQuery>
-    environment={Environment}
-    query={graphql`
+    <QueryRenderer<CommentPageQuery>
+      environment={Environment}
+      query={graphql`
       query CommentPageQuery($questionId: Int) {
         comments(questionId: $questionId) {
           id
@@ -51,11 +28,52 @@ const CommentPage: React.FC = () => (
         }
       }
     `}
-    variables={{
-      questionId: 1,
-    }}
-    render={renderQuery}
-  />
-);
+      variables={{
+        questionId: 1,
+      }}
+      render={({ error, props }) => {
+        if (!props) {
+          return <div>...로딩중</div>;
+        }
+
+        if (error) {
+          return <div>...에러발생</div>;
+        }
+
+        return (
+          <section>
+            <h2>
+              댓글
+            </h2>
+            {props.comments.length === 0
+              ? <p>댓글이 없습니다</p>
+              : (
+                <ol>
+                  {props.comments.map((comment) => (
+                    <li key={comment.id}>
+                      <Comment comment={comment} />
+                    </li>
+                  ))}
+                </ol>
+              )}
+            <form onSubmit={handleOnSubmit}>
+              <label htmlFor="commentInput">
+                유저프로필
+                <input
+                  type="text"
+                  id="commentInput"
+                  placeholder="제 생각에는..."
+                  value={commentInput}
+                  onChange={handleOnChangeInput}
+                />
+              </label>
+              <input type="submit" value="등록" />
+            </form>
+          </section>
+        );
+      }}
+    />
+  );
+};
 
 export default CommentPage;

--- a/client/src/page/CommentPage.tsx
+++ b/client/src/page/CommentPage.tsx
@@ -1,12 +1,30 @@
-import React, { useState, useCallback } from 'react';
-import { QueryRenderer, graphql } from 'react-relay';
+import React, {
+  useState, useCallback, Suspense, useEffect,
+} from 'react';
+import {
+  graphql, usePreloadedQuery, useQueryLoader, PreloadedQuery,
+} from 'react-relay';
 
-import Environment from '../graphql';
 import { CommentPageQuery } from '../__generated__/CommentPageQuery.graphql';
 
 import Comment from '../components/Example/Comment';
 
-const CommentPage: React.FC = () => {
+type Props = {
+  commentQueryRef: PreloadedQuery<CommentPageQuery>
+}
+
+const CommentQuery = graphql`
+  query CommentPageQuery($questionId: Int) {
+    comments(questionId: $questionId) {
+      id
+      ...Comment_comment
+    }
+  }
+`;
+
+const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
+  const { comments } = usePreloadedQuery(CommentQuery, commentQueryRef);
+
   const [commentInput, setCommentInput] = useState('');
 
   const handleOnChangeInput = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
@@ -18,61 +36,63 @@ const CommentPage: React.FC = () => {
   }, []);
 
   return (
-    <QueryRenderer<CommentPageQuery>
-      environment={Environment}
-      query={graphql`
-      query CommentPageQuery($questionId: Int) {
-        comments(questionId: $questionId) {
-          id
-          ...Comment_comment
-        }
-      }
-    `}
-      variables={{
-        questionId: 1,
-      }}
-      render={({ error, props }) => {
-        if (!props) {
-          return <div>...로딩중</div>;
-        }
+    <section>
+      <h2>
+        댓글
+      </h2>
+      {comments.length === 0
+        ? <p>댓글이 없습니다</p>
+        : (
+          <ol>
+            {comments.map((comment) => (
+              <li key={comment.id}>
+                <Comment comment={comment} />
+              </li>
+            ))}
+          </ol>
+        )}
+      <form onSubmit={handleOnSubmit}>
+        <label htmlFor="commentInput">
+          유저프로필
+          <input
+            type="text"
+            id="commentInput"
+            placeholder="제 생각에는..."
+            value={commentInput}
+            onChange={handleOnChangeInput}
+          />
+        </label>
+        <input type="submit" value="등록" />
+      </form>
+    </section>
+  );
+};
 
-        if (error) {
-          return <div>...에러발생</div>;
-        }
+const CommentPage: React.FC = () => {
+  const [
+    commentQueryRef,
+    loadQuery,
+    disposeQuery,
+  ] = useQueryLoader<CommentPageQuery>(CommentQuery);
 
-        return (
-          <section>
-            <h2>
-              댓글
-            </h2>
-            {props.comments.length === 0
-              ? <p>댓글이 없습니다</p>
-              : (
-                <ol>
-                  {props.comments.map((comment) => (
-                    <li key={comment.id}>
-                      <Comment comment={comment} />
-                    </li>
-                  ))}
-                </ol>
-              )}
-            <form onSubmit={handleOnSubmit}>
-              <label htmlFor="commentInput">
-                유저프로필
-                <input
-                  type="text"
-                  id="commentInput"
-                  placeholder="제 생각에는..."
-                  value={commentInput}
-                  onChange={handleOnChangeInput}
-                />
-              </label>
-              <input type="submit" value="등록" />
-            </form>
-          </section>
-        );
-      }}
-    />
+  useEffect(() => {
+    loadQuery({ questionId: 1 });
+    return () => {
+      disposeQuery();
+    };
+  }, [loadQuery, disposeQuery]);
+
+  return (
+    <>
+      <Suspense fallback="로딩중..">
+        {commentQueryRef != null
+          ? (
+            <CommentContainer
+              commentQueryRef={commentQueryRef}
+            />
+          ) : null}
+      </Suspense>
+    </>
   );
 };
 

--- a/client/src/page/CommentPage.tsx
+++ b/client/src/page/CommentPage.tsx
@@ -64,7 +64,7 @@ const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
     commitMutation<CommentPageMutation>(Environment, {
       mutation: CommentMutation,
       variables: {
-        questionId: 1,
+        questionId: 1, // TODO : 임시로 questionId: 1 불러옴. 질문 상세 페이지 완성 후 변수화 시킬 예정
         userEmail: 'inseo@test.com',
         content: commentInput,
       },
@@ -124,6 +124,7 @@ const CommentPage: React.FC = () => {
   ] = useQueryLoader<CommentPageQuery>(CommentQuery);
 
   useEffect(() => {
+    // TODO : 임시로 questionId: 1 불러옴. 질문 상세 페이지 완성 후 변수화 시킬 예정
     loadQuery({ questionId: 1 });
     return () => {
       disposeQuery();

--- a/client/src/page/CommentPage.tsx
+++ b/client/src/page/CommentPage.tsx
@@ -2,6 +2,7 @@ import React, {
   useState,
   Suspense,
   useEffect,
+  useCallback,
 } from 'react';
 
 import {
@@ -53,11 +54,11 @@ const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
 
   const [commentInput, setCommentInput] = useState('');
 
-  const handleOnChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleOnChangeInput = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setCommentInput(event.target.value);
-  };
+  }, []);
 
-  const handleOnSubmit = (event: React.FormEvent) => {
+  const handleOnSubmit = useCallback((event: React.FormEvent) => {
     event.preventDefault();
 
     commitMutation<CommentPageMutation>(Environment, {
@@ -80,7 +81,7 @@ const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
     });
 
     setCommentInput('');
-  };
+  }, [commentInput]);
 
   return (
     <section>

--- a/client/src/page/CommentPage.tsx
+++ b/client/src/page/CommentPage.tsx
@@ -9,14 +9,13 @@ import {
   graphql,
   usePreloadedQuery,
   useQueryLoader,
+  useMutation,
   PreloadedQuery,
 } from 'react-relay';
-import { commitMutation, RecordSourceSelectorProxy } from 'relay-runtime';
+import { RecordSourceSelectorProxy } from 'relay-runtime';
 
 import { CommentPageQuery } from '../__generated__/CommentPageQuery.graphql';
 import { CommentPageMutation } from '../__generated__/CommentPageMutation.graphql';
-
-import Environment from '../graphql';
 
 import Comment from '../components/Example/Comment';
 
@@ -50,6 +49,8 @@ const CommentMutation = graphql`
 `;
 
 const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
+  const [commitComment, isLoading] = useMutation<CommentPageMutation>(CommentMutation);
+
   const { comments } = usePreloadedQuery(CommentQuery, commentQueryRef);
 
   const [commentInput, setCommentInput] = useState('');
@@ -61,8 +62,7 @@ const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
   const handleOnSubmit = useCallback((event: React.FormEvent) => {
     event.preventDefault();
 
-    commitMutation<CommentPageMutation>(Environment, {
-      mutation: CommentMutation,
+    commitComment({
       variables: {
         questionId: 1, // TODO : 임시로 questionId: 1 불러옴. 질문 상세 페이지 완성 후 변수화 시킬 예정
         userEmail: 'inseo@test.com',
@@ -82,6 +82,10 @@ const CommentContainer: React.FC<Props> = ({ commentQueryRef }) => {
 
     setCommentInput('');
   }, [commentInput]);
+
+  if (isLoading) {
+    return <div>댓글 등록중..</div>;
+  }
 
   return (
     <section>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2685,7 +2685,7 @@ caniuse-lite@^1.0.30001219:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz#0a80de4cdf62e1770bb46a30d884fc8d633e3958"
   integrity sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4364,6 +4364,16 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-graphql-schema@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/get-graphql-schema/-/get-graphql-schema-2.1.2.tgz#ffa418534224a75cd7afc8f87b70109ca9ec3fe9"
+  integrity sha512-1z5Hw91VrE3GrpCZE6lE8Dy+jz4kXWesLS7rCSjwOxf5BOcIedAZeTUJRIeIzmmR+PA9CKOkPTYFRJbdgUtrxA==
+  dependencies:
+    chalk "^2.4.1"
+    graphql "^14.0.2"
+    minimist "^1.2.0"
+    node-fetch "^2.2.0"
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
@@ -4501,6 +4511,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0,
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graphql@^14.0.2:
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
+  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
+  dependencies:
+    iterall "^1.2.2"
 
 graphql@^15.5.1:
   version "15.5.1"
@@ -5267,6 +5284,11 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterall@^1.2.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 iterate-iterator@^1.0.1:
   version "1.0.1"
@@ -6367,7 +6389,7 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
## Why

## What


https://user-images.githubusercontent.com/52442237/128637139-95e6fa82-029a-4448-8eaf-9c857815ab6d.mov


- QueryRenderer를  hook으로 변경했습니다.
- 댓글을 확인할 수 있습니다
- 댓글을 입력할 수 있습니다
- 새 댓글을 입력하면 페이지에 실시간으로 반영됩니다(relay store를 활용)

## Notes

- [참고자료](https://medium.com/entria/wrangling-the-client-store-with-the-relay-modern-updater-function-5c32149a71ac)