### PR TITLE
[Client] 드롭다운 컴포넌트 구현

### DIFF
--- a/client/src/components/common/DropDown.tsx
+++ b/client/src/components/common/DropDown.tsx
@@ -1,0 +1,74 @@
+import React, {
+  Fragment, ReactElement, useRef, useState,
+} from 'react';
+import styled from '@emotion/styled';
+
+import useGetBoundingClientRect from '../../hooks/useGetBoundingClientRect';
+
+interface Sheet {
+  title: string | ReactElement
+  onClick: () => void
+}
+
+interface Props {
+  isOpen: boolean
+  sheets: Sheet[]
+}
+
+const DropDown: React.FC<Props> = ({ isOpen, sheets }) => {
+  const [mount, setMount] = useState(false);
+  const [height, setHeight] = useState(0);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useGetBoundingClientRect(dropdownRef, (rect) => {
+    setMount(true);
+    setHeight(rect.height);
+  });
+
+  return (
+    <DropDownArea ref={dropdownRef} mount={mount} isOpen={isOpen} heightValue={height}>
+      {sheets.map(({ title, onClick }, index) => (
+        <Fragment key={index.toString()}>
+          <Item type="button" onClick={onClick}>
+            {title}
+          </Item>
+          <Divider />
+        </Fragment>
+      ))}
+    </DropDownArea>
+  );
+};
+
+const DropDownArea = styled.div<{ mount: boolean; isOpen: boolean; heightValue: number }>`
+  position: absolute;
+  left: 0;
+  top: 100%;
+  transition: 200ms height, 200ms opacity;
+  overflow: hidden;
+
+  ${({ mount, isOpen, heightValue }) => {
+    if (mount) {
+      return isOpen
+        ? `
+          height: ${heightValue}px;
+          opacity: 1;
+        `
+        : `
+          height: 0;
+          opacity: 0;
+        `;
+    }
+    return '';
+  }}
+`;
+const Item = styled.button`
+  display: block;
+  width: max-content;
+  padding: 8px;
+`;
+const Divider = styled.hr`
+  width: 100%;
+  margin: 0;
+`;
+
+export default DropDown;

--- a/client/src/hooks/useGetBoundingClientRect.tsx
+++ b/client/src/hooks/useGetBoundingClientRect.tsx
@@ -1,0 +1,20 @@
+import { RefObject, useEffect } from 'react';
+
+const useGetBoundingClientRect = (
+  ref: RefObject<HTMLElement>,
+  callback: (rect: DOMRect) => void,
+) => {
+  useEffect(() => {
+    const element = ref.current;
+
+    if (!element) {
+      callback({} as DOMRect);
+      return;
+    }
+
+    const rect = element.getBoundingClientRect();
+    callback(rect);
+  }, []);
+};
+
+export default useGetBoundingClientRect;


### PR DESCRIPTION
## Why

- 문제의 정렬 버튼을 사용할 때 필요한 드롭다운을 임시구현함

## What

- useGetBoundingClientRect 훅 구현

## Show

![Aug-16-2021 01-19-59](https://user-images.githubusercontent.com/59194356/129485272-2e0d4254-0cae-4bcb-86a2-b8a13e1b719b.gif)
